### PR TITLE
bugfix

### DIFF
--- a/homeassistant/HomeassistantApp.qml
+++ b/homeassistant/HomeassistantApp.qml
@@ -131,7 +131,7 @@ App {
     property real homeAssistantSlider1Min : 0.0
     property real homeAssistantSlider1Step : 0.0
     property int homeAssistantSlider1Options : 0
-    property string imgNotSelected : "./drawables/notSelected.png"
+    property string imgNotSelected : "./drawables/notselected.png"
     property string imgSelected : "./drawables/selected.png"
 
     property variant homeAssistantSlidersJson : {


### PR DESCRIPTION
This should fix this:
file:///qmf/qml/apps/homeassistant/HomeassistantScreen.qml:805:17: QML Image: Cannot open: file:///qmf/qml/apps/homeassistant/drawables/notSelected.png

(File was renamed to all lowercase in commit 0ccedf4b5deafa5036ad77bc50e56b0cf5230ff3)